### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a92918222963befc8e09c447bd59881ba1fadb1aa4c5ec577ff12f82e7c23560
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
 
 tests:
   - script:
-      - coco 2>&1 | grep -q 'Usage: "Coco Grammar.ATG {Option}'"
+      - "coco 2>&1 | grep -q 'Usage: \"Coco Grammar.ATG {Option}'\""
 
 about:
   license: GPL-2.0-or-later


### PR DESCRIPTION
Wrap test script lines containing shell pipes or redirects in quotes. YAML interprets unquoted `|`, `2>&1`, or `:` as special syntax.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
